### PR TITLE
add transformer_page_view export.

### DIFF
--- a/lib/flutter_swiper_view.dart
+++ b/lib/flutter_swiper_view.dart
@@ -7,3 +7,4 @@ export 'src/swiper_pagination.dart';
 export 'src/swiper_control.dart';
 export 'src/swiper_controller.dart';
 export 'src/swiper_plugin.dart';
+export 'src/transformer_page_view.dart';

--- a/lib/src/custom_layout.dart
+++ b/lib/src/custom_layout.dart
@@ -33,7 +33,7 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
 
   @override
   void didChangeDependencies() {
-    WidgetsBinding.instance.addPostFrameCallback(_getSize);
+    WidgetsBinding.instance?.addPostFrameCallback(_getSize);
     super.didChangeDependencies();
   }
 

--- a/lib/src/swiper.dart
+++ b/lib/src/swiper.dart
@@ -5,8 +5,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_swiper_view/flutter_swiper_view.dart';
 
-import 'transformer_page_view.dart';
-
 part 'custom_layout.dart';
 
 typedef SwiperOnTap = void Function(int index);

--- a/lib/src/transformer_page_view.dart
+++ b/lib/src/transformer_page_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:flutter_swiper_view/src/swiper.dart';
 
 import 'index_controller.dart';
 
@@ -10,9 +11,6 @@ import 'index_controller.dart';
 ///
 ///
 ///
-
-const int kMaxValue = 2000000000;
-const int kMiddleValue = 1000000000;
 
 ///  Default auto play transition duration (in millisecond)
 const int kDefaultTransactionDuration = 300;

--- a/lib/src/transformer_page_view.dart
+++ b/lib/src/transformer_page_view.dart
@@ -531,7 +531,7 @@ class _TransformerPageViewState extends State<TransformerPageView> {
       }
     }
     if (_transformer != null) {
-      WidgetsBinding.instance.addPostFrameCallback(_onGetSize);
+      WidgetsBinding.instance?.addPostFrameCallback(_onGetSize);
     }
 
     if (_controller != widget.controller) {
@@ -545,7 +545,7 @@ class _TransformerPageViewState extends State<TransformerPageView> {
   @override
   void didChangeDependencies() {
     if (_transformer != null) {
-      WidgetsBinding.instance.addPostFrameCallback(_onGetSize);
+      WidgetsBinding.instance?.addPostFrameCallback(_onGetSize);
     }
     super.didChangeDependencies();
   }


### PR DESCRIPTION
sometimes we may custom `PageTransformer`, but the `PageTransformer` is in the `src` dir. so that we can not import this class.